### PR TITLE
[Fixed] Captions conflict

### DIFF
--- a/AddFolderToProject.sublime-commands
+++ b/AddFolderToProject.sublime-commands
@@ -1,11 +1,19 @@
-[
-
-   { "caption": "Add Folders To Project", "command": "list_folder_to_add" },
-   { "caption": "Remove This Folder From Project", "command": "remove_actual_folder_from_project" },
-   { "caption": "Add This Folder To Project", "command": "add_actual_folder_to_project" },
-   { "caption": "Create Project From File", "command": "create_project_from_file" },
-   { "caption": "Copy File Path", "command": "copy_file_path" },
-   { "caption": "Copy Dir Path", "command": "copy_dir_path" }
-
-
-]
+[{
+    "caption": "AddFolderToProject: Add Folders To Project",
+    "command": "list_folder_to_add"
+}, {
+    "caption": "AddFolderToProject: Remove This Folder From Project",
+    "command": "remove_actual_folder_from_project"
+}, {
+    "caption": "AddFolderToProject: Add This Folder To Project",
+    "command": "add_actual_folder_to_project"
+}, {
+    "caption": "AddFolderToProject: Create Project From File",
+    "command": "create_project_from_file"
+}, {
+    "caption": "AddFolderToProject: Copy File Path",
+    "command": "copy_file_path"
+}, {
+    "caption": "AddFolderToProject: Copy Dir Path",
+    "command": "copy_dir_path"
+}]


### PR DESCRIPTION
It's a bad practice — not write package name in a caption name.

1. Users may forget names captions. But if they remember the name of a package, and input it in a command palette, they may to see captions name in a command palette.
2. If command work not as expected, users may quick determine package of bad command.
3. No conflicts between packages. For example, caption `Copy File Path` [**already have in Path Tools**](http://i.imgur.com/NQ4zABV.png) package.

![Path Tools](http://i.imgur.com/NQ4zABV.png)

Thanks.
